### PR TITLE
withChild is now renamed withElement and it can now take an object of component

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,14 +272,30 @@ If a new promise is provided to `[name]`, the previously resolved `value` is kep
 Builds an array that maps every item from the `[valueName]` prop with the result of `<Component {...childProps(props)(itemValue, itemIndex)}` and injects it as a `children` prop.
 The prop is only updated if `shouldUpdateOrKeys` returns `true` or if a prop whose name is listed in it changes.
 
-#### `withChild(Component, childProps?, shouldUpdateOrKeys?, valueName?)`
+#### `withElement(Component || { key:Component }, childProps?, shouldUpdateOrKeys?, destination?)`
 
 > ⬆️ `{ [valueName]? }`
 
 > ⬇️ `{ children }`
 
-Builds an element from the provided `Component` with the props from `childProps(props)` and injects it as a `children` prop.
+Builds an element from the provided `Component` with the props from `childProps(props,name?)` and injects it as a `children` prop.
+
+If `Component` is an object like `{key:Component, key2: Component2...}`, an element will be built for every key of the object. The childProps will be called for each of the keys with the `name` parameter containing the key itself
+
 The prop is only updated if `shouldUpdateOrKeys` returns `true` or if a prop whose name is listed in it changes.
+
+```js
+const Article = withElement({ header: 'h1', body: 'p' }, (props, name) => ({
+  children: props.value[name],
+}))(({ children = EMPTY_OBJECT }) => (
+  <div>
+    {children.header}
+    {children.body}
+  </div>
+))
+
+<Article value={{ value: { header: 'Title', body: 'Content' } }} />
+```
 
 ### Type-oriented decorators
 

--- a/demo/index.js
+++ b/demo/index.js
@@ -35,6 +35,7 @@ import {
   withChild,
   EMPTY_OBJECT,
   logProps,
+  withElement,
 } from '../src'
 
 const Text = compose(
@@ -303,6 +304,31 @@ export const Toggle = compose(
   )
 })
 
+function Title() {
+  return $('h1', null, 'Composed children')
+}
+
+function Body({ value }) {
+  return $('p', null, 'body ' + value)
+}
+
+export const ComposedChildren = compose(
+  withProps({
+    value: { body: 'test' },
+  }),
+  withElement({ header: Title, body: Body }, (props, name) => ({
+    ...props,
+    value: props.value[name],
+  })),
+)(function ComposedChildren({ children = EMPTY_OBJECT }) {
+  return $(
+    'div',
+    null,
+    $('div', null, children.header),
+    $('div', null, children.body),
+  )
+})
+
 export const App = compose(
   withProps({
     value: {
@@ -325,7 +351,7 @@ export const App = compose(
   delayable,
   editable,
   object,
-  logProps(),
+  logProps(['value']),
 )(function App(props) {
   const { property } = props
   return $(
@@ -338,6 +364,7 @@ export const App = compose(
     $(Color, property('color')),
     $('h2', null, 'Delayed'),
     $(Toggle, { ...property('toggle'), delay: 2000 }),
+    $(ComposedChildren),
   )
 })
 

--- a/demo/index.js
+++ b/demo/index.js
@@ -325,6 +325,7 @@ export const App = compose(
   delayable,
   editable,
   object,
+  logProps(),
 )(function App(props) {
   const { property } = props
   return $(

--- a/demo/index.js
+++ b/demo/index.js
@@ -304,30 +304,16 @@ export const Toggle = compose(
   )
 })
 
-function Title() {
-  return $('h1', null, 'Composed children')
-}
-
-function Body({ value }) {
-  return $('p', null, 'body ' + value)
-}
-
-export const ComposedChildren = compose(
-  withProps({
-    value: { body: 'test' },
-  }),
-  withElement({ header: Title, body: Body }, (props, name) => ({
-    ...props,
-    value: props.value[name],
-  })),
-)(function ComposedChildren({ children = EMPTY_OBJECT }) {
-  return $(
+const Article = withElement({ header: 'h1', body: 'p' }, (props, name) => ({
+  children: props.value[name],
+}))(({ children = EMPTY_OBJECT }) =>
+  $(
     'div',
     null,
     $('div', null, children.header),
     $('div', null, children.body),
-  )
-})
+  ),
+)
 
 export const App = compose(
   withProps({
@@ -364,7 +350,7 @@ export const App = compose(
     $(Color, property('color')),
     $('h2', null, 'Delayed'),
     $(Toggle, { ...property('toggle'), delay: 2000 }),
-    $(ComposedChildren),
+    $(Article, { value: { header: 'Title', body: 'Content' } }),
   )
 })
 

--- a/demo/index.js
+++ b/demo/index.js
@@ -34,6 +34,7 @@ import {
   withChildren,
   withChild,
   EMPTY_OBJECT,
+  logProps,
 } from '../src'
 
 const Text = compose(

--- a/src/tools.js
+++ b/src/tools.js
@@ -194,6 +194,8 @@ export function called(object, property) {
 export function logProps(propNames, title) {
   /*
   Logs the provided `propNames` whenever they change.
+  The `title` defaults to the component name.
+  If no `propNames` are provided, logs all props.
   */
   return Component =>
     onPropsChange(propNames, props => {

--- a/src/tools.js
+++ b/src/tools.js
@@ -199,7 +199,7 @@ export function logProps(propNames, title) {
     onPropsChange(propNames, props => {
       /* eslint-disable no-console */
       console.group(title || Component.displayName || Component.name)
-      for (let name of propNames) {
+      for (let name of propNames || keys(props)) {
         console.log(name, props[name])
       }
       console.groupEnd()

--- a/src/tools.js
+++ b/src/tools.js
@@ -14,6 +14,7 @@ import {
   upperFirst,
   map,
   identity,
+  mapValues,
 } from 'lodash'
 import {
   branch,
@@ -427,10 +428,19 @@ export function withChild(
   Builds an element from the provided `Component` with the props from `childProps(props)` and injects it as a `[destination]` prop.
   The prop is only updated if `shouldUpdateOrKeys` returns `true` or if a prop whose name is listed in it changes.
   */
+  if (typeof Component === 'function') {
+    return withPropsOnChange(shouldUpdateOrKeys, props => ({
+      [destination]: $(Component, childProps(props, null)),
+    }))
+  }
   return withPropsOnChange(shouldUpdateOrKeys, props => ({
-    [destination]: $(Component, childProps(props)),
+    [destination]: mapValues(Component, (Component, name) =>
+      $(Component, childProps(props, name)),
+    ),
   }))
 }
+
+export const withElement = withChild
 
 export function lazyProperty(object, propertyName, valueBuilder) {
   /*


### PR DESCRIPTION
```js
function Title() {
  return $('h1', null, 'Composed children')
}

function Body({ value }) {
  return $('p', null, 'body ' + value)
}

export const ComposedChildren = compose(
  withProps({
    value: { body: 'test' },
  }),
  withElement({ header: Title, body: Body }, (props, name) => ({
    ...props,
    value: props.value[name],
  })),
)(function ComposedChildren({ children = EMPTY_OBJECT }) {
  return $(
    'div',
    null,
    $('div', null, children.header),
    $('div', null, children.body),
  )
})
```