### PR TITLE
fix(useDelay): nested usage blocks updates

### DIFF
--- a/lib/hooks/useDelay.ts
+++ b/lib/hooks/useDelay.ts
@@ -1,6 +1,6 @@
 import { type DelayOptions, delay } from "futurise";
 
-import { useMemo } from "../dependencies.js";
+import { useLayoutEffect, useMemo } from "../dependencies.js";
 import type { MaybeDelayedFunction } from "../types/MaybeDelayedFunction.js";
 import type { Name, NevoProps, ValueMutator } from "../types.js";
 
@@ -9,8 +9,11 @@ import { useReferencedState } from "./useReferencedState.js";
 /**
  * Delays calls of the value mutator `onChange` while immediately updating the local `value`.
  *
- * @param props Properties according to the NEVO pattern.
- * @param duration The delay duration in milliseconds.
+ * If `onChange` changes while a delayed call is pending, the pending call will be canceled to avoid calling the outdated `onChange`. Therefore, it is important to ensure that the `onChange` function is stable (e.g., by using `useCallback`) when using this hook to prevent unintended cancellations.
+ *
+ * @param props - Properties according to the NEVO pattern.
+ * @param duration - The delay duration in milliseconds.
+ * @param options - Optional configuration for the delay behavior. See {@link DelayOptions} for details.
  * @returns Properties according to the NEVO pattern, with `onChange` being a debounced value mutator.
  */
 export function useDelay<T>(
@@ -30,6 +33,7 @@ export function useDelay<T>(
         return undefined;
       }
       if (duration === undefined) {
+        // Note that this could be already a delayed function
         return props.onChange;
       }
       const delayedOnChange = delay(duration, props.onChange, options);
@@ -61,14 +65,28 @@ export function useDelay<T>(
           },
         },
       );
-    }, [props.onChange, duration]);
+    }, [props.onChange, duration, options?.immediate, options?.throttle]);
 
-  useMemo(() => {
-    if (wrappedOnChange?.pending) {
-      return;
-    }
-    state.current = props.value;
-  }, [props.value, wrappedOnChange]);
+  useLayoutEffect(
+    () => () => {
+      if (duration === undefined) {
+        return;
+      }
+      wrappedOnChange?.cancel?.();
+    },
+    [wrappedOnChange],
+  );
+
+  useMemo(
+    () => {
+      if (duration !== undefined && wrappedOnChange?.pending) {
+        return;
+      }
+      state.current = props.value;
+    },
+    // Intentionally not including `wrappedOnChange` here as only value changes should trigger this effect
+    [props.value],
+  );
 
   return {
     ...props,

--- a/lib/types/ErrorReport.ts
+++ b/lib/types/ErrorReport.ts
@@ -2,6 +2,7 @@ import type { ErrorReportArray } from "./ErrorReportArray";
 import type { ErrorReportObject } from "./ErrorReportObject";
 import type { ErrorReportValue } from "./ErrorReportValue";
 
+// FIXME: Simplify the error report type
 export type ErrorReport<T, U = NonNullable<T>> = [U] extends [
   readonly unknown[],
 ]


### PR DESCRIPTION
Using the delayed `onChange` returned by `useDelay` and providing it
to another `useDelay` without a delay would cause that second `useDelay`
to ignore internal value changes because `onChange.pending` would be
`true` even though it shouldn't.

The fix also considers canceling pending calls if the `onChange`
is updated. This will make inline functions without set with
`useCallback` or `useMemo` not work.